### PR TITLE
Link to the Lean 4 version of this course in 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Formalising Mathematics
 
-**Note that this course was in Lean 3 which is now out of date (end of life). In December 2023 I will be translating this material into Lean 4.**
+> [!WARNING]  
+> This course was in Lean 3 which is now out of date (end of life). The [2024 version of this course](https://github.com/ImperialCollegeLondon/formalising-mathematics-2024) is in Lean 4.
 
 This is the repository for Kevin Buzzard's 2023 course on formalising mathematics in the Lean theorem prover. The course ran from January to March 2023. 
 


### PR DESCRIPTION
This displays as

![image](https://github.com/ImperialCollegeLondon/formalising-mathematics-2023/assets/425260/e7dbc556-66ac-4651-b945-b6971cc8d6e7)
